### PR TITLE
I78 Added label describing method to download QR code.

### DIFF
--- a/app/static/css/viewsession.css
+++ b/app/static/css/viewsession.css
@@ -35,3 +35,7 @@
   font-size: medium;
   padding: 0%;
 }
+
+.grey {
+  color: grey;
+}

--- a/app/templates/viewsession.html
+++ b/app/templates/viewsession.html
@@ -151,6 +151,7 @@
         $(".modal-body").append('<div><p>Session ID: ' + sessionid + '</p></div>')
         $(".modal-body").append('<div><p>Session Name: ' + sessiontitle + '</p></div>')
         $(".modal-body").append("<div id='qrcode'></div>")
+        $(".modal-body").append("<div><p class='grey'>(right-click or drag to download QR code)</p></div>")
         $(".modal-body").append('<div><p>Session Link: <a id="link" href="' + linkUrl + '">' + linkUrl + '</a></p></div>')
 
         new QRCode(document.getElementById("qrcode"), linkUrl);


### PR DESCRIPTION
This pull request adds a label to the session-link modal that describes the ways a user can download the QR code that appears in the modal.

Closes #78.